### PR TITLE
확진+사망, 확진+회복 지도에 추가

### DIFF
--- a/src/js/loadAndProcessData.js
+++ b/src/js/loadAndProcessData.js
@@ -10,24 +10,57 @@ const row = d => {
 
 export const loadAndProcessData = k => {
 
-  const csvpath = './csv/' + k + '.csv'
+  // const csvpath = './csv/' + k + '.csv';
+  let regex = /(.*) \+ (.*)/;
+  if(k.match(regex)) {
+    const csvpath1 = `./csv/${k.replace(regex, "$1")}.csv`;
+    const csvpath2 = `./csv/${k.replace(regex, "$2")}.csv`;
+    
+    return Promise
+      .all([
+        json('https://unpkg.com/visionscarto-world-atlas@0.0.4/world/50m.json'),
+        csv(csvpath1, row),
+        csv(csvpath2, row)
+      ])
+      .then(([topoJSONdata, covidData, covidData2]) => {
+        
+  
+        const countries = feature(topoJSONdata, topoJSONdata.objects.countries);
+        
+  
+        // console.log(confirmed);
+        
+        return {
+          features: countries.features,
+          name: [k.replace(regex, "$1"), k.replace(regex, "$2")],
+          covidData,
+          covidData2
+        };
+      });
+  }
 
-  return Promise
-    .all([ 
-      json('https://unpkg.com/visionscarto-world-atlas@0.0.4/world/50m.json'),
-      csv(csvpath, row)
-    ])
-    .then(([topoJSONdata, covidData]) => {
-      
+  else {
+    const csvpath = `./csv/${k}.csv`;
+    
+    return Promise
+      .all([
+        json('https://unpkg.com/visionscarto-world-atlas@0.0.4/world/50m.json'),
+        csv(csvpath, row)
+      ])
+      .then(([topoJSONdata, covidData]) => {
+        
+  
+        const countries = feature(topoJSONdata, topoJSONdata.objects.countries);
+        
+  
+        // console.log(confirmed);
+        
+        return {
+          features: countries.features,
+          name: [k],
+          covidData
+        };
+      });
+  }
 
-      const countries = feature(topoJSONdata, topoJSONdata.objects.countries);
-      
-
-      // console.log(confirmed);
-      
-      return {
-        features: countries.features,
-        covidData
-      };
-    });
 }


### PR DESCRIPTION
1. 드랍다운에 확진+사망, 확진+회복 탭을 추가함

2. 정규식으로 문자열을 파싱해 확진,사망,회복 / 확진+사망, 확진+회복 케이스 구분

3. loadAndProcessData.js에서 해당 문자열에 맞게 Promise 생성.
(데이터 두개짜리들은 데이터 하나짜리 Promise에 covidData2가 추가됨.)

4. main.js에서, 해당 Promise의 covidData2 유무에 따라 두번째 종류의 원을 생성.