### PR TITLE
2개 원 한꺼번에 선택 & 그래프 2개 동시에 그리기

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -46,6 +46,10 @@ body {
 .country-circle.highlighted {
   stroke-width: 1.5;
 }
+
+.country-circle2.highlighted {
+  stroke-width: 1.5;
+}
 /*
 .country-circle:hover {
   fill: #9a0101;
@@ -58,7 +62,7 @@ body {
   font-family: sans-serif;
 }
 
-.tick circle, .country-circle {
+.tick circle, .country-circle, .country-circle2 {
   stroke: black;
   stroke-width: 0.3;
  

--- a/src/js/loadAndProcessData.js
+++ b/src/js/loadAndProcessData.js
@@ -11,7 +11,7 @@ const row = d => {
 export const loadAndProcessData = k => {
 
   // const csvpath = './csv/' + k + '.csv';
-  let regex = /(.*) \+ (.*)/;
+  const regex = /(.*) \+ (.*)/;
   if(k.match(regex)) {
     const csvpath1 = `./csv/${k.replace(regex, "$1")}.csv`;
     const csvpath2 = `./csv/${k.replace(regex, "$2")}.csv`;


### PR DESCRIPTION
1. 선택되었을 때 stroke width가 늘어나도록 하는 기능을 복구했습니다. 2개 데이터를 표시할 경우 2개 원 모두 하이라이트 되도록 변경했습니다.
2. 그래프도 두개를 동시에 그리도록 했고, scale은 confirmed(두 데이터중 큰 scale)로 그렸습니다.

# 앞으로 구현할 것
1. 현재 슬라이더의 위치를 그래프에도 세로선으로 표시하면 좋을 거 같습니다.
2. 그래프의 범례등을 추가하면 좋을 것 같습니다.

